### PR TITLE
Import correct highlight.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For more about highlight.js, see https://highlightjs.org/
 
-CSHTML is a markup language created by Microsoft for ASP.NET MVC and ASP.NET Core applications. It allows to create markup containing both C# and HTML code. 
+CSHTML is a markup language created by Microsoft for ASP.NET MVC and ASP.NET Core applications. It allows to create markup containing both C# and HTML code.
 
 For more about the CSHTML Razor syntax here: https://docs.microsoft.com/en-us/aspnet/core/mvc/views/razor.
 
@@ -13,9 +13,9 @@ Simply include the `highlight.js` script package in your webpage or node app, lo
 If you're not using a build system and just want to embed this in your webpage:
 
 ```html
-<script type="text/javascript" src="/path/to/highlightjs/highlight.pack.js"></script>
-<script type="text/javascript" src="/path/to/highlightjs-cshtml-razor/cshtml-razor.js"></script>
-<script type="text/javascript">
+<script src="/path/to/highlight.js/highlight.pack.js"></script>
+<script src="/path/to/highlightjs-cshtml-razor/cshtml-razor.js"></script>
+<script>
     hljs.registerLanguage('cshtml-razor', window.hljsDefineCshtmlRazor);
     hljs.initHighlightingOnLoad();
 </script>
@@ -24,7 +24,7 @@ If you're not using a build system and just want to embed this in your webpage:
 If you're using webpack / rollup / browserify / node:
    
 ```javascript
-var hljs = require('highlightjs');
+var hljs = require('highlight.js');
 var hljsDefineCshtmlRazor = require('highlightjs-cshtml-razor');
 
 hljsDefineCshtmlRazor(hljs);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highlightjs-cshtml-razor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -97,10 +97,10 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "highlightjs": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/highlightjs/-/highlightjs-9.10.0.tgz",
-      "integrity": "sha1-/Km3jdqjsavKidbD7hBa0nCoAZA=",
+    "highlight.js": {
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
       "dev": true
     },
     "inflight": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
   },
   "homepage": "https://github.com/highlightjs/highlightjs-cshtml-razor#readme",
   "devDependencies": {
-    "highlightjs": "^9.10.0",
+    "highlight.js": "^9.15.10",
     "mocha": "^5.2.0",
     "should": "^13.2.3"
-  }
+  },
+  "dependencies": {}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var should = require('should');
 var promisify = require("util").promisify;
 let path = require('path');
-let hljs = require("highlightjs");
+let hljs = require("highlight.js");
 const fs = require("fs");
 let hljsDefineCshtmlRazor = require("../cshtml-razor");
 


### PR DESCRIPTION
Unfortunately, someone squatted "highlightjs" on npm and it's pointing to an old version... the official one is "highlight.js". I'll see about getting that fixed, but in the meantime... 